### PR TITLE
grpc unix socket and auto threadiness (falco 0.24.0)

### DIFF
--- a/deploy/kubernetes/k8s-audit-only/falco.yaml
+++ b/deploy/kubernetes/k8s-audit-only/falco.yaml
@@ -182,7 +182,7 @@ http_output:
 # grpc:
 #   enabled: true
 #   bind_address: "0.0.0.0:5060"
-#   threadiness: 8
+#   threadiness: 0
 #   private_key: "/etc/falco/certs/server.key"
 #   cert_chain: "/etc/falco/certs/server.crt"
 #   root_certs: "/etc/falco/certs/ca.crt"
@@ -191,7 +191,7 @@ http_output:
 grpc:
   enabled: false
   bind_address: "unix:///var/run/falco/falco.sock"
-  threadiness: 8
+  threadiness: 0
 
 # gRPC output service.
 # By default it is off.

--- a/deploy/kubernetes/k8s-audit-only/falco.yaml
+++ b/deploy/kubernetes/k8s-audit-only/falco.yaml
@@ -167,21 +167,35 @@ http_output:
   enabled: false
   url: http://some.url
 
-# gRPC server configuration.
-# The gRPC server is secure by default (mutual TLS) so you need to generate certificates and update their paths here.
+# Falco supports running a gRPC server with two main binding types
+# 1. Over the network with mandatory mutual TLS authentication (mTLS)
+# 2. Over a local unix socket with no authentication
+# By default, the gRPC server is disabled, with no enabled services (see grpc_output)
+# please comment/uncomment and change accordingly the options below to configure it.
+# Important note: if Falco has any troubles creating the gRPC server
+# this information will be logged, however the main Falco daemon will not be stopped.
+# gRPC server over network with (mandatory) mutual TLS configuration.
+# This gRPC server is secure by default so you need to generate certificates and update their paths here.
 # By default the gRPC server is off.
 # You can configure the address to bind and expose it.
 # By modifying the threadiness configuration you can fine-tune the number of threads (and context) it will use.
+# grpc:
+#   enabled: true
+#   bind_address: "0.0.0.0:5060"
+#   threadiness: 8
+#   private_key: "/etc/falco/certs/server.key"
+#   cert_chain: "/etc/falco/certs/server.crt"
+#   root_certs: "/etc/falco/certs/ca.crt"
+
+# gRPC server using an unix socket
 grpc:
   enabled: false
-  bind_address: "0.0.0.0:5060"
+  bind_address: "unix:///var/run/falco/falco.sock"
   threadiness: 8
-  private_key: "/etc/falco/certs/server.key"
-  cert_chain: "/etc/falco/certs/server.crt"
-  root_certs: "/etc/falco/certs/ca.crt"
 
 # gRPC output service.
 # By default it is off.
 # By enabling this all the output events will be kept in memory until you read them with a gRPC client.
+# Make sure to have a consumer for them or leave this disabled.
 grpc_output:
   enabled: false

--- a/deploy/kubernetes/kernel-and-k8s-audit/.gitignore
+++ b/deploy/kubernetes/kernel-and-k8s-audit/.gitignore
@@ -1,0 +1,1 @@
+falco-config

--- a/deploy/kubernetes/kernel-and-k8s-audit/daemonset-least-privilege.yaml
+++ b/deploy/kubernetes/kernel-and-k8s-audit/daemonset-least-privilege.yaml
@@ -51,6 +51,9 @@ spec:
               name: docker-socket
             - mountPath: /host/run/containerd/containerd.sock
               name: containerd-socket
+            # required to create falco.sock
+            - mountPath: /var/run/falco
+              name: run-falco-fs
             - mountPath: /host/dev
               name: dev-fs
             - mountPath: /host/proc
@@ -65,7 +68,7 @@ spec:
             - mountPath: /host/usr
               name: usr-fs
               readOnly: true
-            - mountPath: /host/etc/
+            - mountPath: /host/etc
               name: etc-fs
               readOnly: true
             - mountPath: /etc/falco
@@ -77,6 +80,10 @@ spec:
         - name: containerd-socket
           hostPath:
             path: /run/containerd/containerd.sock
+        # required to create falco.sock
+        - name: run-falco-fs
+          hostPath:
+              path: /var/run/falco
         - name: dev-fs
           hostPath:
             path: /dev

--- a/deploy/kubernetes/kernel-and-k8s-audit/daemonset.yaml
+++ b/deploy/kubernetes/kernel-and-k8s-audit/daemonset.yaml
@@ -35,6 +35,9 @@ spec:
               name: docker-socket
             - mountPath: /host/run/containerd/containerd.sock
               name: containerd-socket
+            # required to create falco.sock
+            - mountPath: /var/run/falco
+              name: run-falco-fs
             - mountPath: /host/dev
               name: dev-fs
               readOnly: true
@@ -50,7 +53,7 @@ spec:
             - mountPath: /host/usr
               name: usr-fs
               readOnly: true
-            - mountPath: /host/etc/
+            - mountPath: /host/etc
               name: etc-fs
               readOnly: true
             - mountPath: /etc/falco
@@ -62,6 +65,10 @@ spec:
         - name: containerd-socket
           hostPath:
             path: /run/containerd/containerd.sock
+        # required to create falco.sock
+        - name: run-falco-fs
+          hostPath:
+              path: /var/run/falco
         - name: dev-fs
           hostPath:
             path: /dev

--- a/deploy/kubernetes/kernel-and-k8s-audit/falco.yaml
+++ b/deploy/kubernetes/kernel-and-k8s-audit/falco.yaml
@@ -182,7 +182,7 @@ http_output:
 # grpc:
 #   enabled: true
 #   bind_address: "0.0.0.0:5060"
-#   threadiness: 8
+#   threadiness: 0
 #   private_key: "/etc/falco/certs/server.key"
 #   cert_chain: "/etc/falco/certs/server.crt"
 #   root_certs: "/etc/falco/certs/ca.crt"
@@ -191,7 +191,7 @@ http_output:
 grpc:
   enabled: false
   bind_address: "unix:///var/run/falco/falco.sock"
-  threadiness: 8
+  threadiness: 0
 
 # gRPC output service.
 # By default it is off.

--- a/deploy/kubernetes/kernel-and-k8s-audit/falco.yaml
+++ b/deploy/kubernetes/kernel-and-k8s-audit/falco.yaml
@@ -167,21 +167,35 @@ http_output:
   enabled: false
   url: http://some.url
 
-# gRPC server configuration.
-# The gRPC server is secure by default (mutual TLS) so you need to generate certificates and update their paths here.
+# Falco supports running a gRPC server with two main binding types
+# 1. Over the network with mandatory mutual TLS authentication (mTLS)
+# 2. Over a local unix socket with no authentication
+# By default, the gRPC server is disabled, with no enabled services (see grpc_output)
+# please comment/uncomment and change accordingly the options below to configure it.
+# Important note: if Falco has any troubles creating the gRPC server
+# this information will be logged, however the main Falco daemon will not be stopped.
+# gRPC server over network with (mandatory) mutual TLS configuration.
+# This gRPC server is secure by default so you need to generate certificates and update their paths here.
 # By default the gRPC server is off.
 # You can configure the address to bind and expose it.
 # By modifying the threadiness configuration you can fine-tune the number of threads (and context) it will use.
+# grpc:
+#   enabled: true
+#   bind_address: "0.0.0.0:5060"
+#   threadiness: 8
+#   private_key: "/etc/falco/certs/server.key"
+#   cert_chain: "/etc/falco/certs/server.crt"
+#   root_certs: "/etc/falco/certs/ca.crt"
+
+# gRPC server using an unix socket
 grpc:
   enabled: false
-  bind_address: "0.0.0.0:5060"
+  bind_address: "unix:///var/run/falco/falco.sock"
   threadiness: 8
-  private_key: "/etc/falco/certs/server.key"
-  cert_chain: "/etc/falco/certs/server.crt"
-  root_certs: "/etc/falco/certs/ca.crt"
 
 # gRPC output service.
 # By default it is off.
 # By enabling this all the output events will be kept in memory until you read them with a gRPC client.
+# Make sure to have a consumer for them or leave this disabled.
 grpc_output:
   enabled: false


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

/kind sandbox


**Any specific area of the project related to this PR?**

/area deploy


**What this PR does / why we need it**:

This PR: 
- [x] adds the [gRPC Unix socket](https://github.com/falcosecurity/falco/pull/1217) support for deployment resources.
Consumers (eg. `falco-exporter`, see also https://github.com/falcosecurity/falco-exporter/pull/33)  should be aware that the socket is created and shared within the default path `/var/run/falco.sock`
- [x] set `threadiness` to 0 by default as per https://github.com/falcosecurity/falco/pull/1271

These modifications above are required to work with Falco 0.24.0

To be kept on hold until the next Falco release.
/hold

**Which issue(s) this PR fixes**:


Fixes #

**Special notes for your reviewer**: 
/cc @leodido 
/cc @fntlnz 
/cc @maxgio92

For testing purpose please use `falcosecurity/falco:master` which has gRPC over Unix socket support.

~~Note: I'm also going to update the [Falco's helm chart](https://github.com/falcosecurity/charts) soon.~~