### PR TITLE
Add AuditSink also for kernel+Kubernetes audit use case

### DIFF
--- a/deploy/kubernetes/kernel-and-k8s-audit/audit-sink.yaml.in
+++ b/deploy/kubernetes/kernel-and-k8s-audit/audit-sink.yaml.in
@@ -1,0 +1,16 @@
+apiVersion: auditregistration.k8s.io/v1alpha1
+kind: AuditSink
+metadata:
+  name: falco-audit-sink
+spec:
+  policy:
+    level: RequestResponse
+    stages:
+      - ResponseComplete
+      - ResponseStarted
+  webhook:
+    throttle:
+      qps: 10
+      burst: 15
+    clientConfig:
+      url: "http://$FALCO_SERVICE_CLUSTERIP:8765/k8s-audit"


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area deploy

**What this PR does / why we need it**:

Add Kubernetes dynamic audit backend configuration (`AuditSink`) also for kernel and Kubernetes audit.