### PR TITLE
Add initial support for Kustomizations

### DIFF
--- a/deploy/kubernetes/falco/kustomization.yaml
+++ b/deploy/kubernetes/falco/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./templates/serviceaccount.yaml
+- ./templates/clusterrole.yaml
+- ./templates/clusterrolebinding.yaml
+- ./templates/configmap.yaml
+- ./templates/daemonset.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a first `Kustomization` under deploy/kubernetes/falco to build an initial standard variant.

Kustomize lets configure applications in a composable manner through overlays without templating.
It enables also to generate resources with builtin and custom plugins.
Furthermore Kustomize binary is embedded into `kubectl` (executed with `-k` option).

This can be considered a base Falco `Kustomization` to be used, patched to compose different variants (for example Falco with Sidekick).

**Special notes for your reviewer**:

To build this `Kustomization` is as simple as:
```
kustomize build deploy/kubernetes/falco
```

To apply the built manifests:
```
kustomize build deploy/kubernetes/falco | kubectl apply -f -

# or with kubectl-embedded version

kubectl apply -k deploy/kubernetes/falco
```

I think this is a [step zero](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/#1-make-a-kustomization-file) to create other bases and [overlays](https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/#2-create-variants-using-overlays).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area integrations