### PR TITLE
update(deploy/kubernetes): Falco deployment files

### DIFF
--- a/deploy/kubernetes/falco-exporter/templates/daemonset.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/daemonset.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: falco-exporter
+  labels:
+    app.kubernetes.io/name: falco-exporter
+    app.kubernetes.io/instance: falco-exporter
+    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: falco-exporter-0.5.1
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: falco-exporter
+      app.kubernetes.io/instance: falco-exporter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: falco-exporter
+        app.kubernetes.io/instance: falco-exporter
+    spec:
+      serviceAccountName: falco-exporter
+      securityContext:
+        {}
+      containers:
+        - name: falco-exporter
+          securityContext:
+            {}
+          image: "falcosecurity/falco-exporter:0.5.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - /usr/bin/falco-exporter
+            - --client-socket=unix:///var/run/falco/falco.sock
+            - --timeout=2m
+            - --listen-address=0.0.0.0:9376
+          ports:
+            - name: metrics
+              containerPort: 9376
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 19376
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 19376
+          resources:
+            {}
+          volumeMounts:
+            - mountPath: /var/run/falco
+              name: falco-socket-dir
+              readOnly: true
+      volumes:
+        - name: falco-socket-dir
+          hostPath:
+            path: /var/run/falco
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+---

--- a/deploy/kubernetes/falco-exporter/templates/service.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: falco-exporter
+  annotations:
+    prometheus.io/port: "9376"
+    prometheus.io/scrape: "true"
+  labels:
+    app.kubernetes.io/name: falco-exporter
+    app.kubernetes.io/instance: falco-exporter
+    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: falco-exporter-0.5.1
+  namespace: default
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - port: 9376
+      targetPort: 9376
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: falco-exporter
+    app.kubernetes.io/instance: falco-exporter
+---

--- a/deploy/kubernetes/falco-exporter/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: falco-exporter
+  labels:
+    app.kubernetes.io/name: falco-exporter
+    app.kubernetes.io/instance: falco-exporter
+    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: falco-exporter-0.5.1
+  namespace: default
+---

--- a/deploy/kubernetes/falco-exporter/templates/tests/test-connection.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "falco-exporter-test-connection"
+  labels:
+    app.kubernetes.io/name: falco-exporter
+    app.kubernetes.io/instance: falco-exporter
+    app.kubernetes.io/version: "0.5.0"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: falco-exporter-0.5.1
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['falco-exporter:9376']
+  restartPolicy: Never


### PR DESCRIPTION
Updating Falco deployment files (automatically generated by helm template). Made using the [update-falco-k8s-manifests](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml) ProwJob. Do not edit this PR.