### PR TITLE
update(deploy/kubernetes): Falco deployment files

### DIFF
--- a/deploy/kubernetes/falco/templates/clusterrole.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.12.0"
+    chart: "falco-1.13.0"
     release: "falco"
     heritage: "Helm"
 rules:

--- a/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.12.0"
+    chart: "falco-1.13.0"
     release: "falco"
     heritage: "Helm"
 subjects:

--- a/deploy/kubernetes/falco/templates/configmap.yaml
+++ b/deploy/kubernetes/falco/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.12.0"
+    chart: "falco-1.13.0"
     release: "falco"
     heritage: "Helm"
 data:
@@ -150,6 +150,7 @@ data:
       enabled: true
       listen_port: 8765
       k8s_audit_endpoint: /k8s-audit
+      k8s_healthz_endpoint: /healthz
       ssl_enabled: false
       ssl_certificate: /etc/falco/certs/server.pem
 

--- a/deploy/kubernetes/falco/templates/daemonset.yaml
+++ b/deploy/kubernetes/falco/templates/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.12.0"
+    chart: "falco-1.13.0"
     release: "falco"
     heritage: "Helm"
 spec:
@@ -20,7 +20,7 @@ spec:
         app: falco
         role: security
       annotations:
-        checksum/config: 18f37750e3ed46c7475048f3e6eebd7f346d2e7c678c1952399156688b0dc100
+        checksum/config: 2c735b06a57dbab2157270a14afa98f63b4ae409993787aabb743ee4f696aacd
         checksum/rules: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/certs: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
     spec:
@@ -51,6 +51,20 @@ spec:
             - https://$(KUBERNETES_SERVICE_HOST)
             - -pk
           env:
+          livenessProbe:
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+            periodSeconds: 15
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 15
+            httpGet:
+              path: /healthz
+              port: http
           volumeMounts:
             - mountPath: /host/var/run/docker.sock
               name: docker-socket

--- a/deploy/kubernetes/falco/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/falco/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.12.0"
+    chart: "falco-1.13.0"
     release: "falco"
     heritage: "Helm"
 ---


### PR DESCRIPTION
Updating Falco deployment files (automatically generated by helm template). Made using the [update-falco-k8s-manifests](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml) ProwJob. Do not edit this PR.