### PR TITLE
update(deploy/kubernetes): Falco deployment files

### DIFF
--- a/deploy/kubernetes/falco/templates/clusterrole.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.15.7"
+    chart: "falco-1.16.0"
     release: "falco"
     heritage: "Helm"
 rules:

--- a/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.15.7"
+    chart: "falco-1.16.0"
     release: "falco"
     heritage: "Helm"
 subjects:

--- a/deploy/kubernetes/falco/templates/configmap.yaml
+++ b/deploy/kubernetes/falco/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.15.7"
+    chart: "falco-1.16.0"
     release: "falco"
     heritage: "Helm"
 data:
@@ -40,6 +40,12 @@ data:
     # itself (e.g. "File below a known binary directory opened for writing
     # (user=root ....") in the json output.
     json_include_output_property: true
+
+    # When using json output, whether or not to include the "tags" property
+    # itself in the json output. If set to true, outputs caused by rules
+    # with no tags will have a "tags" field set to an empty array. If set to
+    # false, the "tags" field will not be included in the json output at all.
+    json_include_tags_property: true
 
     # Send information logs to stderr and/or syslog Note these are *not* security
     # notification logs! These are just Falco lifecycle (and possibly error) logs.
@@ -187,8 +193,14 @@ data:
 
     grpc_output:
       enabled: false
+    
+    # Container orchestrator metadata fetching params
+    metadata_download:
+      max_mb: 100
+      chunk_wait_us: 1000
+      watch_freq_sec: 1
 
-  application_rules.yaml: |
+  application_rules.yaml: |-
     #
     # Copyright (C) 2019 The Falco Authors.
     #
@@ -408,7 +420,7 @@ data:
     #   tags: [users, container]
   
     # Or override/append to any rule, macro, or list from the Default Rules
-  falco_rules.yaml: |+
+  falco_rules.yaml: |
     #
     # Copyright (C) 2020 The Falco Authors.
     #
@@ -2166,7 +2178,6 @@ data:
         (container.image.repository startswith "602401143452.dkr.ecr" or
          container.image.repository startswith "877085696533.dkr.ecr" or
          container.image.repository startswith "800184023465.dkr.ecr" or
-         container.image.repository startswith "602401143452.dkr.ecr" or
          container.image.repository startswith "918309763551.dkr.ecr" or
          container.image.repository startswith "961992271922.dkr.ecr" or
          container.image.repository startswith "590381155156.dkr.ecr" or
@@ -3158,7 +3169,12 @@ data:
           "xmr-eu1.nanopool.org","xmr-eu2.nanopool.org",
           "xmr-jp1.nanopool.org","xmr-us-east1.nanopool.org",
           "xmr-us-west1.nanopool.org","xmr.crypto-pool.fr",
-          "xmr.pool.minergate.com", "rx.unmineable.com"
+          "xmr.pool.minergate.com", "rx.unmineable.com",
+          "ss.antpool.com","dash.antpool.com",
+          "eth.antpool.com","zec.antpool.com",
+          "xmc.antpool.com","btm.antpool.com",
+          "stratum-dash.antpool.com","stratum-xmc.antpool.com",
+          "stratum-btm.antpool.com"
           ]
   
     - list: https_miner_domains
@@ -3175,7 +3191,12 @@ data:
         "stratum-ltc.antpool.com",
         "stratum-zec.antpool.com",
         "stratum.antpool.com",
-        "xmr.crypto-pool.fr"
+        "xmr.crypto-pool.fr",
+        "ss.antpool.com",
+        "stratum-dash.antpool.com",
+        "stratum-xmc.antpool.com",
+        "stratum-btm.antpool.com",
+        "btm.antpool.com"
       ]
   
     - list: http_miner_domains
@@ -3488,8 +3509,7 @@ data:
     # Application rules have moved to application_rules.yaml. Please look
     # there if you want to enable them by adding to
     # falco_rules.local.yaml.
-  
-  k8s_audit_rules.yaml: |+
+  k8s_audit_rules.yaml: |
     #
     # Copyright (C) 2019 The Falco Authors.
     #

--- a/deploy/kubernetes/falco/templates/daemonset.yaml
+++ b/deploy/kubernetes/falco/templates/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.15.7"
+    chart: "falco-1.16.0"
     release: "falco"
     heritage: "Helm"
 spec:
@@ -20,7 +20,7 @@ spec:
         app: falco
         role: security
       annotations:
-        checksum/config: b3e7235ffa87a7967af2b7acfb01e2f827cc2f50b18c466f64c6bb64b386244b
+        checksum/config: aecc3ddbb979d07354a14d46a27ba7e99a96b6dcf16ca053295edc8b844026c4
         checksum/rules: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/certs: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
     spec:
@@ -30,7 +30,7 @@ spec:
           key: node-role.kubernetes.io/master
       containers:
         - name: falco
-          image: docker.io/falcosecurity/falco:0.29.1
+          image: docker.io/falcosecurity/falco:0.30.0
           imagePullPolicy: IfNotPresent
           resources:
             limits:
@@ -49,8 +49,13 @@ spec:
             - /var/run/secrets/kubernetes.io/serviceaccount/token
             - -k
             - https://$(KUBERNETES_SERVICE_HOST)
+            - --k8s-node="${FALCO_K8S_NODE_NAME}"
             - -pk
           env:
+            - name: FALCO_K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           livenessProbe:
             initialDelaySeconds: 60
             timeoutSeconds: 5

--- a/deploy/kubernetes/falco/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/falco/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.15.7"
+    chart: "falco-1.16.0"
     release: "falco"
     heritage: "Helm"
 ---


### PR DESCRIPTION
Updating Falco deployment files (automatically generated by helm template). Made using the [update-falco-k8s-manifests](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml) ProwJob. Do not edit this PR.