### PR TITLE
update(deploy/kubernetes): Falco deployment files

### DIFF
--- a/deploy/kubernetes/falco-exporter/templates/daemonset.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/daemonset.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: falco-exporter
     app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: falco-exporter-0.7.0
+    helm.sh/chart: falco-exporter-0.7.1
   namespace: default
 spec:
   selector:

--- a/deploy/kubernetes/falco-exporter/templates/service.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: falco-exporter
     app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: falco-exporter-0.7.0
+    helm.sh/chart: falco-exporter-0.7.1
   namespace: default
 spec:
   clusterIP: None

--- a/deploy/kubernetes/falco-exporter/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/falco-exporter/templates/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
     app.kubernetes.io/instance: falco-exporter
     app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: falco-exporter-0.7.0
+    helm.sh/chart: falco-exporter-0.7.1
   namespace: default
 ---


### PR DESCRIPTION
Updating Falco deployment files (automatically generated by helm template). Made using the [update-falco-k8s-manifests](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml) ProwJob. Do not edit this PR.