### PR TITLE
update(deploy/kubernetes): Falco deployment files

### DIFF
--- a/deploy/kubernetes/falco/templates/clusterrole.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.17.4"
+    chart: "falco-1.17.6"
     release: "falco"
     heritage: "Helm"
 rules:

--- a/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
+++ b/deploy/kubernetes/falco/templates/clusterrolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: falco
   labels:
     app: falco
-    chart: "falco-1.17.4"
+    chart: "falco-1.17.6"
     release: "falco"
     heritage: "Helm"
 subjects:

--- a/deploy/kubernetes/falco/templates/configmap.yaml
+++ b/deploy/kubernetes/falco/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.17.4"
+    chart: "falco-1.17.6"
     release: "falco"
     heritage: "Helm"
 data:
@@ -215,7 +215,7 @@ data:
 
     http_output:
       enabled: false
-      url: http://some.url
+      url: 'http://falco-falcosidekick:2801'
       user_agent: falcosecurity/falco
 
 
@@ -251,7 +251,7 @@ data:
     # Make sure to have a consumer for them or leave this disabled.
     grpc_output:
       enabled: false
-    
+
     # Container orchestrator metadata fetching params
     metadata_download:
       max_mb: 100

--- a/deploy/kubernetes/falco/templates/daemonset.yaml
+++ b/deploy/kubernetes/falco/templates/daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.17.4"
+    chart: "falco-1.17.6"
     release: "falco"
     heritage: "Helm"
 spec:
@@ -20,7 +20,7 @@ spec:
         app: falco
         role: security
       annotations:
-        checksum/config: 828286e0226557cc929ac7f588f4fd885a9bc868e9a1fcfd9fe13812fd3a5f25
+        checksum/config: 75515295113035f4d82acda763f30284294d66977c8ba278797e40205514c40b
         checksum/rules: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
         checksum/certs: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
     spec:

--- a/deploy/kubernetes/falco/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/falco/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     app: falco
-    chart: "falco-1.17.4"
+    chart: "falco-1.17.6"
     release: "falco"
     heritage: "Helm"
 ---


### PR DESCRIPTION
Updating Falco deployment files (automatically generated by helm template). Made using the [update-falco-k8s-manifests](https://github.com/falcosecurity/test-infra/blob/master/config/jobs/update-falco-k8s-manifests/update-falco-k8s-manifests.yaml) ProwJob. Do not edit this PR.