### PR TITLE
update(OWNERS): move inactive maintainers to emeritus approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,8 @@
 approvers:
+  - leogr
+  - maxgio92
+emeritus_approvers:
   - leodido
   - fntlnz
   - kris-nova
-  - leogr
   - nestorsalceda
-  - maxgio92
-reviewers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - leogr
-  - nestorsalceda
-  - maxgio92


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

For https://github.com/falcosecurity/evolution/issues/157 (see: https://github.com/falcosecurity/evolution/issues/157), this PR proposes to move to `emeritus_approvers` maintainers that have been inactive in the past 6 months, as for our governance (see: https://github.com/falcosecurity/.github/blob/master/GOVERNANCE.md#project-inactivity). Maintainers are invited to have a discussion and take a decision.

cc @falcosecurity/evolution-maintainers 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
