### PR TITLE
fix: correct exoner4ted affiliation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@ As per our [governance](./GOVERNANCE.md), the lists of current maintainers and c
 
 These lists summarize the content of all [OWNERS](./GOVERNANCE.md#repository-ownership) files across all The Falco Project repositories.
 
-Last update: **<!-- LATEST-UPDATE -->2022-11-28T09:01:35Z<!-- /LATEST-UPDATE -->**
+Last update: **<!-- LATEST-UPDATE -->2022-11-30T15:29:34Z<!-- /LATEST-UPDATE -->**
 
 ## Core Maintainers
 
@@ -46,5 +46,5 @@ Last update: **<!-- LATEST-UPDATE -->2022-11-28T09:01:35Z<!-- /LATEST-UPDATE -->
 - [Radu Andries](https://github.com/admiral0), Independent
 - [Teryl Taylor](https://github.com/terylt), IBM
 - [Thomas Labarussias](https://github.com/issif), Sysdig
-- [exoner4ted](https://github.com/exoner4ted), UNKNOWN
+- [exoner4ted](https://github.com/exoner4ted), Secureworks
 <!-- /MAINTAINERS-LIST -->

--- a/maintainers.yaml
+++ b/maintainers.yaml
@@ -174,6 +174,6 @@
   - https://github.com/falcosecurity/falcosidekick-ui
 - name: exoner4ted
   github: https://github.com/exoner4ted
-  company: UNKNOWN
+  company: Secureworks
   projects:
   - https://github.com/falcosecurity/driverkit

--- a/people/affiliations.json
+++ b/people/affiliations.json
@@ -147,7 +147,7 @@
         "name": "Luca Guerra",
         "company": "Sysdig"
     },
-    "EXONER4TED": {
+    "exoner4ted": {
         "name": "Logan Bond",
         "company": "Secureworks"
     }


### PR DESCRIPTION
Signed-off-by: Jason Dellaluce <jasondellaluce@gmail.com>

**What type of PR is this?**

/kind cleanup

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

The tool that periodically generates `maintainers.yaml` (github.com/leodido/maintainers-generator) is case-sensitive, so the affiliation of exoner4ted got lost in the process.

**Special notes for your reviewer**: