### PR TITLE
fix: generate maintainers.md entry for subdir maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@ As per our [governance](./GOVERNANCE.md), the lists of current maintainers and c
 
 These lists summarize the content of all [OWNERS](./GOVERNANCE.md#repository-ownership) files across all The Falco Project repositories.
 
-Last update: **<!-- LATEST-UPDATE -->2022-12-04T09:01:50Z<!-- /LATEST-UPDATE -->**
+Last update: **<!-- LATEST-UPDATE -->2022-12-05T09:31:16Z<!-- /LATEST-UPDATE -->**
 
 ## Core Maintainers
 
@@ -33,6 +33,7 @@ Last update: **<!-- LATEST-UPDATE -->2022-12-04T09:01:50Z<!-- /LATEST-UPDATE -->
 - [Frank Jogeleit](https://github.com/fjogeleit), LOVOO
 - [Fred Araujo](https://github.com/araujof), IBM
 - [Grzegorz Nosek](https://github.com/gnosek), Sysdig
+- [Hendrik Brueckner](https://github.com/hbrueckner), IBM
 - [Jason Dellaluce](https://github.com/jasondellaluce), Sysdig
 - [Jonah Jones](https://github.com/jonahjon), Amazon
 - [Leonardo Di Donato](https://github.com/leodido), Independent

--- a/utils/cmd/maintainers.go
+++ b/utils/cmd/maintainers.go
@@ -59,8 +59,11 @@ func maintainersTextEditor(s string, core bool) (string, error) {
 		added := false
 		for _, r := range repositories {
 			for _, url := range m.Projects {
-				if url == r.URL() {
-					if !added && (!core || r.Status == utils.RepositoryStatusOfficial) {
+				isCoreRepo := r.Status == utils.RepositoryStatusOfficial
+				isRepoMaintainer := url == r.URL()
+				isSubDirMaintainer := strings.HasPrefix(url, r.URL()+"/")
+				if isRepoMaintainer || isSubDirMaintainer {
+					if !added && (!core || isCoreRepo && !isSubDirMaintainer) {
 						list = append(list, m)
 						added = true
 					}


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

Fixes the automated tool to add entries in MAINTAINERS.md for maintainers of repo subdirectories.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**: