### PR TITLE
 Move org.yaml from test-infra to evolution repository

### DIFF
--- a/org.yaml
+++ b/org.yaml
@@ -560,6 +560,7 @@ orgs:
           - FedeDP
           - maxgio92
           - zuc
+          - EXONER4TED
         privacy: closed
         repos:
           kernel-crawler: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -434,6 +434,7 @@ orgs:
           - dwindsor
           - FedeDP
           - EXONER4TED
+          - Lowaiz
         privacy: closed
         repos:
           driverkit: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -646,6 +646,7 @@ orgs:
           - maxgio92
           - zuc
           - jonahjon
+          - fededp
         privacy: closed
         repos:
           test-infra: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -7,6 +7,10 @@ orgs:
     has_organization_projects: true
     has_repository_projects: true
     members_can_create_repositories: false
+    billing_email: ""
+    company: ""
+    email: ""
+    location: ""
 
     admins:
       - caniszczyk

--- a/org.yaml
+++ b/org.yaml
@@ -640,6 +640,11 @@ orgs:
         maintainers:
           - leogr
           - LucaGuerra
+        members:
+          - fededp
+          - jasondellaluce
+          - andreagit97
+          - mstemm
         privacy: closed
         repos:
           rules: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -80,7 +80,7 @@ orgs:
         has_wiki: false
       contrib:
         allow_merge_commit: false
-        description: The Falco Project Community
+        description: Community sandbox to test-drive ideas/projects/code
         has_projects: true
         has_wiki: false
       deploy-kubernetes:

--- a/org.yaml
+++ b/org.yaml
@@ -32,6 +32,7 @@ orgs:
       - fjogeleit
       - gnosek
       - hbrueckner
+      - incertum
       - Issif
       - jonahjon
       - Kaizhe
@@ -547,6 +548,7 @@ orgs:
           - LucaGuerra
           - Andreagit97
           - hbrueckner
+          - incertum
         privacy: closed
         repos:
           libs: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -202,7 +202,7 @@ orgs:
     teams:
       admins:
         description: admins of the org
-        maintainers:
+        members:
           - caniszczyk
           - ldegio
           - leogr
@@ -213,9 +213,8 @@ orgs:
           advocacy: admin
       charts-maintainers:
         description: maintainers of the Falco Helm charts
-        maintainers:
-          - leogr
         members:
+          - leogr
           - cpanato
           - Issif
         privacy: closed
@@ -223,41 +222,38 @@ orgs:
           charts: maintain
       client-go-maintainers:
         description: maintainers of client-go
-        maintainers:
+        members:
           - leodido
           - leogr
-        members:
           - markyjackson-taulia
         privacy: closed
         repos:
           client-go: maintain
       client-py-maintainers:
         description: maintainers of client-py
-        maintainers:
-          - leodido
         members:
+          - leodido
           - mmat11
         privacy: closed
         repos:
           client-py: maintain
       client-rs-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
         privacy: closed
         repos:
           client-rs: maintain
       community-maintainers:
         description: maintainers of the community repository
-        maintainers:
-          - leogr
         members:
+          - leogr
         privacy: closed
         repos:
           community: maintain
       deploy-kubernetes-maintainers:
         description: maintainers of deploy-kubernetes
-        maintainers:
+        members:
           - leogr
           - maxgio92
           - jasondellaluce
@@ -266,7 +262,7 @@ orgs:
           deploy-kubernetes: maintain
       driverkit-maintainers:
         description: maintainers of driverkit
-        maintainers:
+        members:
           - leodido
           - dwindsor
           - fededp
@@ -275,7 +271,7 @@ orgs:
           driverkit: maintain
       event-generator-maintainers:
         description: maintainers of the event-generator
-        maintainers:
+        members:
           - leogr
           - fededp
         privacy: closed
@@ -283,9 +279,8 @@ orgs:
           event-generator: maintain
       evolution-maintainers:
         description: maintainers of the evolution repository
-        maintainers:
-          - leogr
         members:
+          - leogr
           - nestorsalceda
           - maxgio92
         privacy: closed
@@ -293,7 +288,7 @@ orgs:
           evolution: maintain
       falco-aws-terraform-maintainers:
         description: ""
-        maintainers:
+        members:
           - mstemm
           - leogr
           - jasondellaluce
@@ -304,39 +299,36 @@ orgs:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
         description: maintainers of falco-exporter
-        maintainers:
+        members:
           - leogr
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
         description: maintainers of the main Falco repository
-        maintainers:
+        members:
           - leogr
           - mstemm
           - jasondellaluce
           - fededp
-        members:
           - Kaizhe
         privacy: closed
         repos:
           falco: maintain
       falcoctl-maintainers:
         description: falcoctl maintainers
-        maintainers:
+        members:
           - leogr
           - mstemm
-        members:
           - markyjackson-taulia
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
         description: maintainers of falcosidekick
-        maintainers:
+        members:
           - leogr
           - Issif
-        members:
           - cpanato
           - fjogeleit
         privacy: closed
@@ -344,10 +336,9 @@ orgs:
           falcosidekick: maintain
       falcosidekick-ui-maintainers:
         description: maintainers of falcosidekick-ui
-        maintainers:
+        members:
           - leogr
           - Issif
-        members:
           - cpanato
           - fjogeleit
         privacy: closed
@@ -355,23 +346,22 @@ orgs:
           falcosidekick-ui: maintain
       github-maintainers:
         description: maintainers of the .github repository
-        maintainers:
+        members:
           - leogr
           - maxgio92
         repos:
           .github: maintain
       katacoda-scenarios-maintainers:
         description: ""
-        maintainers:
-          - leogr
         members:
+          - leogr
           - developer-guy
         privacy: closed
         repos:
           katacoda-scenarios: maintain
       kernel-crawler-maintainers:
         description: kernel-crawler maintainers
-        maintainers:
+        members:
           - fededp
           - maxgio92
           - leogr
@@ -381,20 +371,18 @@ orgs:
           kernel-crawler: maintain
       kilt-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
           - gnosek
-        members:
           - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
         description: libs maintainers
-        maintainers:
+        members:
           - ldegio
           - leogr
-        members:
           - Andreagit97
           - gnosek
           - fededp
@@ -404,7 +392,7 @@ orgs:
           libs: maintain
       libs-sdk-go-maintainers:
         description: libs-sdk-go maintainers
-        maintainers:
+        members:
           - araujof
           - terylt
           - leogr
@@ -415,7 +403,7 @@ orgs:
           libs-sdk-go: maintain
       machine_users:
         description: bots
-        maintainers:
+        members:
           - poiana
         privacy: closed
         repos:
@@ -445,53 +433,48 @@ orgs:
           test-infra: admin
       pdig-maintainers:
         description: maintainers of pdig
-        maintainers:
+        members:
           - leodido
           - ldegio
-        members:
           - gnosek
         privacy: closed
         repos:
           pdig: maintain
       plugin-sdk-cpp-maintainers:
         description: ""
-        maintainers:
+        members:
           - leodido
           - ldegio
           - leogr
           - mstemm
-        members:
           - fededp
         privacy: closed
         repos:
           plugin-sdk-cpp: read
       plugin-sdk-go-maintainers:
         description: ""
-        maintainers:
+        members:
           - ldegio
           - leogr
           - mstemm
-        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
         description: ""
-        maintainers:
+        members:
           - ldegio
           - leogr
           - mstemm
-        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       test-infra-maintainers:
         description: Maintainers of falcosecurity/test-infra
-        maintainers:
-          - leogr
         members:
+          - leogr
           - maxgio92
           - zuc
           - jonahjon
@@ -500,9 +483,8 @@ orgs:
           test-infra: maintain
       website-maintainers:
         description: maintainers of falco-website and docs
-        maintainers:
-          - leogr
         members:
+          - leogr
           - jasondellaluce
           - Issif
         privacy: closed

--- a/org.yaml
+++ b/org.yaml
@@ -17,14 +17,14 @@ orgs:
       - thelinuxfoundation
 
     members:
-      - araujof
-      - Andreagit97
       - admiral0
+      - Andreagit97
+      - araujof
       - bencer
       - cpanato
       - darryk10
       - dwindsor
-      - fededp
+      - FedeDP
       - fjogeleit
       - gnosek
       - Issif
@@ -34,9 +34,9 @@ orgs:
       - kris-nova
       - leodido
       - LucaGuerra
-      - mfdii
       - markyjackson-taulia
       - maxgio92
+      - mfdii
       - mmat11
       - Molter73
       - terylt

--- a/org.yaml
+++ b/org.yaml
@@ -29,7 +29,6 @@ orgs:
       - fjogeleit
       - gnosek
       - Issif
-      - jasondellaluce
       - jonahjon
       - Kaizhe
       - kris-nova

--- a/org.yaml
+++ b/org.yaml
@@ -20,6 +20,7 @@ orgs:
 
     members:
       - admiral0
+      - ahmedameenaim
       - alacuku
       - Andreagit97
       - araujof
@@ -707,6 +708,7 @@ orgs:
           - mstemm
         members:
           - jasondellaluce
+          - ahmedameenaim
         privacy: closed
         repos:
           plugins: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -20,38 +20,25 @@ orgs:
       - araujof
       - Andreagit97
       - admiral0
-      - airadier
       - bencer
       - cpanato
       - darryk10
-      - developer-guy
       - dwindsor
       - fededp
       - fjogeleit
       - gnosek
-      - henridf
       - Issif
       - jasondellaluce
       - jonahjon
       - Kaizhe
-      - KeisukeYamashita
       - kris-nova
       - leodido
-      - lucperkins
-      - markyjackson-taulia
-      - mattpag
-      - maxgio92
       - mfdii
+      - markyjackson-taulia
+      - maxgio92
       - mmat11
       - Molter73
-      - mumoshu
       - nestorsalceda
-      - nibalizer
-      - pabloopez
-      - radhikapc
-      - Rajakavitha1
-      - sreedaum
-      - tembleking
       - terylt
       - zuc
 
@@ -229,7 +216,6 @@ orgs:
         maintainers:
           - leogr
         members:
-          - nibalizer
           - cpanato
           - Issif
         privacy: closed
@@ -241,7 +227,6 @@ orgs:
           - leodido
           - leogr
         members:
-          - mfdii
           - markyjackson-taulia
         privacy: closed
         repos:
@@ -267,8 +252,6 @@ orgs:
         maintainers:
           - leogr
         members:
-          - nibalizer
-          - mfdii
         privacy: closed
         repos:
           community: maintain
@@ -354,11 +337,8 @@ orgs:
           - leogr
           - Issif
         members:
-          - nibalizer
           - cpanato
           - fjogeleit
-          - developer-guy
-          - KeisukeYamashita
         privacy: closed
         repos:
           falcosidekick: maintain
@@ -379,7 +359,6 @@ orgs:
           - leogr
         members:
           - developer-guy
-          - pabloopez
         privacy: closed
         repos:
           katacoda-scenarios: maintain
@@ -526,11 +505,7 @@ orgs:
         maintainers:
           - leogr
         members:
-          - lucperkins
-          - mfdii
-          - radhikapc
           - jasondellaluce
-          - Rajakavitha1
           - Issif
         privacy: closed
         repos:

--- a/org.yaml
+++ b/org.yaml
@@ -78,6 +78,11 @@ orgs:
         description: The Falco Project Community
         has_projects: true
         has_wiki: false
+      contrib:
+        allow_merge_commit: false
+        description: The Falco Project Community
+        has_projects: true
+        has_wiki: false
       deploy-kubernetes:
         allow_merge_commit: false
         allow_squash_merge: false
@@ -259,6 +264,15 @@ orgs:
         privacy: closed
         repos:
           community: maintain
+      contrib-maintainers:
+        description: maintainers of falcosecurity/contrib
+        members:
+          - leogr
+          - maxgio92
+          - jasondellaluce
+        privacy: closed
+        repos:
+          community: maintain
       deploy-kubernetes-maintainers:
         description: maintainers of falcosecurity/deploy-kubernetes
         members:
@@ -420,6 +434,7 @@ orgs:
           client-py: admin
           client-rs: admin
           community: admin
+          contrib: admin
           deploy-kubernetes: admin
           driverkit: admin
           event-generator: admin

--- a/org.yaml
+++ b/org.yaml
@@ -10,7 +10,6 @@ orgs:
 
     admins:
       - caniszczyk
-      - fntlnz
       - kris-nova
       - ldegio
       - leodido
@@ -220,7 +219,6 @@ orgs:
           - caniszczyk
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - thelinuxfoundation
           - mstemm
@@ -232,7 +230,6 @@ orgs:
         description: maintainers of the Falco Helm charts
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -246,7 +243,6 @@ orgs:
         description: maintainers of client-go
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -268,7 +264,6 @@ orgs:
         description: ""
         maintainers:
           - leodido
-          - fntlnz
         privacy: closed
         repos:
           client-rs: maintain
@@ -276,7 +271,6 @@ orgs:
         description: maintainers of the community repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -298,7 +292,6 @@ orgs:
         description: maintainers of driverkit
         maintainers:
           - leodido
-          - fntlnz
           - dwindsor
           - fededp
         privacy: closed
@@ -308,7 +301,6 @@ orgs:
         description: maintainers of the event-generator
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
           - fededp
@@ -319,7 +311,6 @@ orgs:
         description: maintainers of the evolution repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -351,7 +342,6 @@ orgs:
         description: maintainers of the main Falco repository
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -366,7 +356,6 @@ orgs:
         description: falcoctl maintainers
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -425,7 +414,6 @@ orgs:
         description: ""
         maintainers:
           - leodido
-          - fntlnz
           - gnosek
         members:
           - admiral0
@@ -437,7 +425,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
         members:
           - Andreagit97
@@ -492,7 +479,6 @@ orgs:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:
@@ -505,7 +491,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
         members:
           - gnosek
         privacy: closed
@@ -516,7 +501,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
         members:
@@ -529,7 +513,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -543,7 +526,6 @@ orgs:
         maintainers:
           - leodido
           - ldegio
-          - fntlnz
           - leogr
           - mstemm
           - kris-nova
@@ -556,7 +538,6 @@ orgs:
         description: Maintainers of falcosecurity/test-infra
         maintainers:
           - leodido
-          - fntlnz
           - leogr
         members:
           - maxgio92
@@ -569,7 +550,6 @@ orgs:
         description: maintainers of falco-website and docs
         maintainers:
           - leodido
-          - fntlnz
           - leogr
           - kris-nova
         members:

--- a/org.yaml
+++ b/org.yaml
@@ -663,6 +663,7 @@ orgs:
         description: maintainers of falcosecurity/perperibolos-syncer
         maintainers:
           - maxgio92
+          - leogr
         members: []
         privacy: closed
         repos:

--- a/org.yaml
+++ b/org.yaml
@@ -38,7 +38,6 @@ orgs:
       - maxgio92
       - mmat11
       - Molter73
-      - nestorsalceda
       - terylt
       - vjjmiras
       - zuc

--- a/org.yaml
+++ b/org.yaml
@@ -63,11 +63,13 @@ orgs:
         description: Go client and SDK for Falco
         has_projects: true
       client-py:
+        archived: true
         allow_merge_commit: false
         description: Python client and SDK for Falco
         has_projects: true
         has_wiki: false
       client-rs:
+        archived: true
         description: The rust language implementation of the Falco client
         has_projects: true
       community:
@@ -176,6 +178,7 @@ orgs:
         description: System inspection library
         has_projects: true
       pdig:
+        archived: true
         description: ptrace-based event producer for udig
         has_projects: true
         has_wiki: false

--- a/org.yaml
+++ b/org.yaml
@@ -437,6 +437,7 @@ orgs:
         members:
           - FedeDP
           - jasondellaluce
+          - Andreagit97
         privacy: closed
         repos:
           falco: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -220,7 +220,7 @@ orgs:
         privacy: closed
         repos:
           advocacy: admin
-      core-maitainers:
+      core-maintainers:
         description: Core maintainers of The Falco Project
         members:
           - andreagit97

--- a/org.yaml
+++ b/org.yaml
@@ -349,9 +349,10 @@ orgs:
           - leogr
           - mstemm
           - kris-nova
+          - jasondellaluce
+          - FedeDP
         members:
           - Kaizhe
-          - jasondellaluce
         privacy: closed
         repos:
           falco: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -353,6 +353,13 @@ orgs:
         privacy: closed
         repos:
           falcosidekick-ui: maintain
+      github-maintainers:
+        description: maintainers of the .github repository
+        maintainers:
+          - leogr
+          - maxgio92
+        repos:
+          .github: maintain
       katacoda-scenarios-maintainers:
         description: ""
         maintainers:
@@ -436,15 +443,6 @@ orgs:
           plugins: admin
           template-repository: admin
           test-infra: admin
-      maintainers:
-        description: falconers (can dismiss reviews and apply milestones)
-        maintainers:
-          - leogr
-        members:
-          - jasondellaluce
-        privacy: secret
-        repos:
-          .github: maintain
       pdig-maintainers:
         description: maintainers of pdig
         maintainers:

--- a/org.yaml
+++ b/org.yaml
@@ -271,6 +271,14 @@ orgs:
         allow_squash_merge: false
         description: Falco plugins registry
         has_projects: true
+      syscalls-bumper:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: A tool to automatically update supported syscalls in libs
+        has_projects: false
+        has_wiki: false  
       template-repository:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -575,6 +583,7 @@ orgs:
           plugin-sdk-cpp: admin
           plugin-sdk-go: admin
           plugins: admin
+          syscalls-bumper: admin
           test-infra: admin
       pdig-maintainers:
         description: maintainers of falcosecurity/pdig

--- a/org.yaml
+++ b/org.yaml
@@ -28,7 +28,7 @@ orgs:
       - cpanato
       - developer-guy
       - dwindsor
-      - FedeDP
+      - fededp
       - fjogeleit
       - gnosek
       - henridf
@@ -298,6 +298,7 @@ orgs:
           - leodido
           - fntlnz
           - dwindsor
+          - fededp
         privacy: closed
         repos:
           driverkit: maintain
@@ -308,6 +309,7 @@ orgs:
           - fntlnz
           - leogr
           - kris-nova
+          - fededp
         privacy: closed
         repos:
           event-generator: maintain
@@ -352,7 +354,7 @@ orgs:
           - mstemm
           - kris-nova
           - jasondellaluce
-          - FedeDP
+          - fededp
         members:
           - Kaizhe
         privacy: closed
@@ -438,7 +440,7 @@ orgs:
         members:
           - Andreagit97
           - gnosek
-          - FedeDP
+          - fededp
           - Molter73
         privacy: closed
         repos:
@@ -516,7 +518,7 @@ orgs:
           - leogr
           - mstemm
         members:
-          - FedeDP
+          - fededp
         privacy: closed
         repos:
           plugin-sdk-cpp: read

--- a/org.yaml
+++ b/org.yaml
@@ -25,6 +25,7 @@ orgs:
       - araujof
       - bencer
       - cpanato
+      - cappellinsamuele
       - darryk10
       - dwindsor
       - ewilderj

--- a/org.yaml
+++ b/org.yaml
@@ -468,6 +468,7 @@ orgs:
         members:
           - Issif
           - jasondellaluce
+          - vjjmiras
         privacy: closed
         repos:
           falco-website: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -41,6 +41,7 @@ orgs:
       - krisnova
       - leodido
       - loresuso
+      - Lowaiz
       - markyjackson-taulia
       - maxgio92
       - mfdii

--- a/org.yaml
+++ b/org.yaml
@@ -417,7 +417,7 @@ orgs:
         description: bots
         maintainers:
           - poiana
-        privacy: secret
+        privacy: closed
         repos:
           .github: admin
           charts: admin

--- a/org.yaml
+++ b/org.yaml
@@ -322,6 +322,7 @@ orgs:
         members:
           - leogr
           - maxgio92
+          - jasondellaluce
         privacy: closed
         repos:
           evolution: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -7,10 +7,6 @@ orgs:
     has_organization_projects: true
     has_repository_projects: true
     members_can_create_repositories: false
-    billing_email: ""
-    company: ""
-    email: ""
-    location: ""
 
     admins:
       - caniszczyk

--- a/org.yaml
+++ b/org.yaml
@@ -35,6 +35,7 @@ orgs:
       - Kaizhe
       - kris-nova
       - leodido
+      - loresuso
       - LucaGuerra
       - markyjackson-taulia
       - maxgio92

--- a/org.yaml
+++ b/org.yaml
@@ -538,6 +538,7 @@ orgs:
         maintainers:
           - leogr
           - mstemm
+          - jasondellaluce
         members:
           - gnosek
           - FedeDP

--- a/org.yaml
+++ b/org.yaml
@@ -16,6 +16,7 @@ orgs:
       - poiana
       - thelinuxfoundation
       - jasondellaluce
+      - LucaGuerra
 
     members:
       - admiral0
@@ -37,7 +38,6 @@ orgs:
       - krisnova
       - leodido
       - loresuso
-      - LucaGuerra
       - markyjackson-taulia
       - maxgio92
       - mfdii

--- a/org.yaml
+++ b/org.yaml
@@ -27,6 +27,7 @@ orgs:
       - cpanato
       - darryk10
       - dwindsor
+      - ewilderj
       - EXONER4TED
       - FedeDP
       - fjogeleit
@@ -173,6 +174,13 @@ orgs:
         description: Source code of the official Falco website
         has_projects: true
         homepage: https://falco.org
+      flycheck-falco-rules:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        description: Falco Rules Syntax Checker for Emacs, Using Flycheck
+        default_branch: main
+        has_projects: true
       falcoctl:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -286,7 +294,7 @@ orgs:
         default_branch: main
         description: A tool to automatically update supported syscalls in libs
         has_projects: false
-        has_wiki: false  
+        has_wiki: false
       template-repository:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -473,6 +481,15 @@ orgs:
         privacy: closed
         repos:
           falco-website: maintain
+      flycheck-falco-rules-maintainers:
+        description: maintainers of falcosecurity/flycheck-falco-rules
+        maintainers:
+          - mstemm
+          - ewilderj
+        members:
+        privacy: closed
+        repos:
+          flycheck-falco-rules: maintain
       falcoctl-maintainers:
         description: maintainers of falcosecurity/falcoctl
         maintainers:
@@ -588,6 +605,7 @@ orgs:
           falcoctl: admin
           falcosidekick: admin
           falcosidekick-ui: admin
+          flycheck-falco-rules: admin
           kernel-crawler: admin
           kilt: admin
           libs: admin

--- a/org.yaml
+++ b/org.yaml
@@ -33,6 +33,7 @@ orgs:
       - Kaizhe
       - kris-nova
       - leodido
+      - LucaGuerra
       - mfdii
       - markyjackson-taulia
       - maxgio92
@@ -392,6 +393,7 @@ orgs:
           - fededp
           - andreagit97
           - molter73
+          - LucaGuerra
         privacy: closed
         repos:
           libs: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -537,6 +537,7 @@ orgs:
           - Molter73
           - LucaGuerra
           - Andreagit97
+          - hbrueckner
         privacy: closed
         repos:
           libs: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -26,6 +26,7 @@ orgs:
       - airadier
       - bencer
       - cpanato
+      - darryk10
       - developer-guy
       - dwindsor
       - fededp

--- a/org.yaml
+++ b/org.yaml
@@ -627,6 +627,16 @@ orgs:
         privacy: closed
         repos:
           plugins: maintain
+      syscalls-bumper-maintainers:
+        description: maintainers of falcosecurity/syscalls-bumper
+        maintainers:
+          - leogr
+        members:
+          - FedeDP
+          - Andreagit97
+        privacy: closed
+        repos:
+          syscalls-bumper: maintain
       test-infra-maintainers:
         description: maintainers of falcosecurity/test-infra
         maintainers:

--- a/org.yaml
+++ b/org.yaml
@@ -261,6 +261,14 @@ orgs:
         description: ptrace-based event producer for udig
         has_projects: true
         has_wiki: false
+      pigeon:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: Secrets and config manager for Falco's infrastructure
+        has_projects: true
+        has_wiki: false
       plugin-sdk-cpp:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -310,6 +318,14 @@ orgs:
         has_projects: true
         has_wiki: false
         homepage: https://prow.falco.org
+      testing:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: All-purpose test suite for Falco and its ecosystem
+        has_projects: true
+        has_wiki: false
 
     teams:
       admins:
@@ -612,11 +628,13 @@ orgs:
           libs: admin
           libs-sdk-go: admin
           pdig: admin
+          pigeon: admin
           plugin-sdk-cpp: admin
           plugin-sdk-go: admin
           plugins: admin
           syscalls-bumper: admin
           test-infra: admin
+          testing: admin
       pdig-maintainers:
         description: maintainers of falcosecurity/pdig
         maintainers:
@@ -627,6 +645,16 @@ orgs:
         privacy: closed
         repos:
           pdig: maintain
+      pigeon-maintainers:
+        description: maintainers of falcosecurity/pigeon
+        maintainers:
+          - jasondellaluce
+        members:
+          - cappellinsamuele
+          - fededp
+        privacy: closed
+        repos:
+          pigeon: maintain
       plugin-sdk-cpp-maintainers:
         description: maintainers of falcosecurity/plugin-sdk-cpp
         maintainers:
@@ -693,3 +721,14 @@ orgs:
         privacy: closed
         repos:
           test-infra: maintain
+      testing-maintainers:
+        description: maintainers of falcosecurity/testing
+        maintainers:
+          - jasondellaluce
+          - leogr
+        members:
+          - andreagit97
+          - lucaguerra
+        privacy: closed
+        repos:
+          testing: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -483,6 +483,7 @@ orgs:
           - leogr
         members:
           - maxgio92
+          - jasondellaluce
         privacy: closed
         repos:
           .github: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -15,6 +15,7 @@ orgs:
       - mstemm
       - poiana
       - thelinuxfoundation
+      - jasondellaluce
 
     members:
       - admiral0

--- a/org.yaml
+++ b/org.yaml
@@ -150,6 +150,7 @@ orgs:
         has_projects: true
         has_wiki: false
       katacoda-scenarios:
+        archived: true
         allow_merge_commit: false
         allow_squash_merge: false
         description: Content more https://katacoda.com/falco/

--- a/org.yaml
+++ b/org.yaml
@@ -19,6 +19,7 @@ orgs:
 
     members:
       - admiral0
+      - alacuku
       - Andreagit97
       - araujof
       - bencer

--- a/org.yaml
+++ b/org.yaml
@@ -487,6 +487,7 @@ orgs:
           - FedeDP
           - jasondellaluce
           - Andreagit97
+          - incertum
         privacy: closed
         repos:
           falco: maintain
@@ -700,6 +701,7 @@ orgs:
           - jasondellaluce
           - andreagit97
           - mstemm
+          - incertum
         privacy: closed
         repos:
           rules: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -263,6 +263,14 @@ orgs:
         description: ptrace-based event producer for udig
         has_projects: true
         has_wiki: false
+      peribolos-syncer:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        default_branch: main
+        description: Tool to synchronize Peribolos configuration with GitHub people sources of truth.
+        has_projects: true
+        has_wiki: false
       pigeon:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -633,6 +641,7 @@ orgs:
           libs: admin
           libs-sdk-go: admin
           pdig: admin
+          peribolos-syncer: admin
           pigeon: admin
           plugin-sdk-cpp: admin
           plugin-sdk-go: admin
@@ -650,6 +659,14 @@ orgs:
         privacy: closed
         repos:
           pdig: maintain
+      peribolos-syncer-maintainers:
+        description: maintainers of falcosecurity/perperibolos-syncer
+        maintainers:
+          - maxgio92
+        members: []
+        privacy: closed
+        repos:
+          peribolos-syncer: maintain
       pigeon-maintainers:
         description: maintainers of falcosecurity/pigeon
         maintainers:

--- a/org.yaml
+++ b/org.yaml
@@ -398,6 +398,7 @@ orgs:
           - leodido
           - dwindsor
           - FedeDP
+          - EXONER4TED
         privacy: closed
         repos:
           driverkit: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -12,7 +12,6 @@ orgs:
       - caniszczyk
       - kris-nova
       - ldegio
-      - leodido
       - leogr
       - mstemm
       - poiana
@@ -37,6 +36,7 @@ orgs:
       - jonahjon
       - Kaizhe
       - KeisukeYamashita
+      - leodido
       - lucperkins
       - markyjackson-taulia
       - mattpag
@@ -217,7 +217,6 @@ orgs:
         description: admins of the org
         maintainers:
           - caniszczyk
-          - leodido
           - ldegio
           - leogr
           - thelinuxfoundation
@@ -229,7 +228,6 @@ orgs:
       charts-maintainers:
         description: maintainers of the Falco Helm charts
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -270,7 +268,6 @@ orgs:
       community-maintainers:
         description: maintainers of the community repository
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -300,7 +297,6 @@ orgs:
       event-generator-maintainers:
         description: maintainers of the event-generator
         maintainers:
-          - leodido
           - leogr
           - kris-nova
           - fededp
@@ -310,7 +306,6 @@ orgs:
       evolution-maintainers:
         description: maintainers of the evolution repository
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -333,7 +328,6 @@ orgs:
       falco-exporter-maintainers:
         description: maintainers of falco-exporter
         maintainers:
-          - leodido
           - leogr
         privacy: closed
         repos:
@@ -341,7 +335,6 @@ orgs:
       falco-maintainers:
         description: maintainers of the main Falco repository
         maintainers:
-          - leodido
           - leogr
           - mstemm
           - kris-nova
@@ -355,7 +348,6 @@ orgs:
       falcoctl-maintainers:
         description: falcoctl maintainers
         maintainers:
-          - leodido
           - leogr
           - mstemm
           - kris-nova
@@ -367,7 +359,6 @@ orgs:
       falcosidekick-maintainers:
         description: maintainers of falcosidekick
         maintainers:
-          - leodido
           - leogr
           - Issif
         members:
@@ -423,7 +414,6 @@ orgs:
       libs-maintainers:
         description: libs maintainers
         maintainers:
-          - leodido
           - ldegio
           - leogr
         members:
@@ -478,7 +468,6 @@ orgs:
       maintainers:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:
@@ -511,7 +500,6 @@ orgs:
       plugin-sdk-go-maintainers:
         description: ""
         maintainers:
-          - leodido
           - ldegio
           - leogr
           - mstemm
@@ -524,7 +512,6 @@ orgs:
       plugins-maintainers:
         description: ""
         maintainers:
-          - leodido
           - ldegio
           - leogr
           - mstemm
@@ -537,7 +524,6 @@ orgs:
       test-infra-maintainers:
         description: Maintainers of falcosecurity/test-infra
         maintainers:
-          - leodido
           - leogr
         members:
           - maxgio92
@@ -549,7 +535,6 @@ orgs:
       website-maintainers:
         description: maintainers of falco-website and docs
         maintainers:
-          - leodido
           - leogr
           - kris-nova
         members:

--- a/org.yaml
+++ b/org.yaml
@@ -396,6 +396,7 @@ orgs:
           - Molter73
           - LucaGuerra
           - Andreagit97
+          - incertum
         privacy: closed
       deploy-kubernetes-maintainers:
         description: maintainers of falcosecurity/deploy-kubernetes

--- a/org.yaml
+++ b/org.yaml
@@ -351,14 +351,6 @@ orgs:
           - maxgio92
         repos:
           .github: maintain
-      katacoda-scenarios-maintainers:
-        description: ""
-        members:
-          - leogr
-          - developer-guy
-        privacy: closed
-        repos:
-          katacoda-scenarios: maintain
       kernel-crawler-maintainers:
         description: kernel-crawler maintainers
         members:

--- a/org.yaml
+++ b/org.yaml
@@ -40,6 +40,7 @@ orgs:
       - Molter73
       - nestorsalceda
       - terylt
+      - vjjmiras
       - zuc
 
     repos:

--- a/org.yaml
+++ b/org.yaml
@@ -272,7 +272,7 @@ orgs:
           - jasondellaluce
         privacy: closed
         repos:
-          community: maintain
+          contrib: maintain
       deploy-kubernetes-maintainers:
         description: maintainers of falcosecurity/deploy-kubernetes
         members:

--- a/org.yaml
+++ b/org.yaml
@@ -49,164 +49,236 @@ orgs:
 
     repos:
       .github:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        default_branch: main
         description: Default community health files
         has_projects: false
         has_wiki: false
       advocacy:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         description: Advocacy machinery
         has_projects: true
       charts:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Community managed Helm charts for running Falco with Kubernetes
         has_projects: true
         has_wiki: false
       client-go:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Go client and SDK for Falco
         has_projects: true
       client-py:
-        archived: true
         allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        archived: true
         description: Python client and SDK for Falco
         has_projects: true
         has_wiki: false
       client-rs:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         description: The rust language implementation of the Falco client
         has_projects: true
       community:
         allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        default_branch: main
         description: The Falco Project Community
         has_projects: true
         has_wiki: false
       contrib:
         allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        default_branch: main
         description: Community sandbox to test-drive ideas/projects/code
         has_projects: true
         has_wiki: false
       deploy-kubernetes:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
+        default_branch: main
         description: Kubernetes deployment resources for Falco
         has_projects: false
         has_wiki: false
       driverkit:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         description: "Kit for building Falco drivers: kernel modules or eBPF probes"
         has_projects: true
       ebpf-probe:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         description: eBPF probe for syscall events
         has_projects: true
       event-generator:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
-        description: Generate a variety of suspect actions that are detected by Falco rulesets
+        description:
+          Generate a variety of suspect actions that are detected by Falco
+          rulesets
         has_projects: true
       evolution:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
+        default_branch: main
         description: Evolution process of The Falco Project
         has_projects: true
         has_wiki: false
       falco:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Cloud Native Runtime Security
         has_projects: true
         has_wiki: false
         homepage: https://falco.org
+      falco-aws-terraform:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        default_branch: main
+        has_projects: true
       falco-exporter:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Prometheus Metrics Exporter for Falco output events
         has_projects: true
-      falco-aws-terraform:
-        default_branch: main
-        has_projects: true
       falco-website:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         description: Hugo content to generate website content. Hosted by the CNCF
         has_projects: true
         homepage: https://falco.org
       falcoctl:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Administrative tooling for Falco
         has_projects: true
         has_wiki: false
       falcosidekick:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: Connect Falco to your ecosystem
         has_projects: true
         has_wiki: false
       falcosidekick-ui:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
         description: A simple WebUI with latest events from Falco
         has_projects: true
         has_wiki: false
-      katacoda-scenarios:
-        archived: true
-        allow_merge_commit: false
-        allow_squash_merge: false
-        description: Content more https://katacoda.com/falco/
-        has_projects: false
-        has_wiki: false
       kernel-crawler:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
+        default_branch: main
         description: A tool to crawl Linux kernel versions
         has_projects: false
         has_wiki: false
       kernel-module:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         has_projects: true
       kilt:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         description: Kilt is a project that defines how to inject foreign apps into containers
-        has_projects: false
+        has_projects: true
         has_wiki: false
       libs:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
-        description: libsinsp, libscap, the kernel module driver, and the eBPF driver sources
+        description:
+          libsinsp, libscap, the kernel module driver, and the eBPF driver
+          sources
         has_projects: true
         has_wiki: false
       libs-sdk-go:
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
+        default_branch: main
         description: Go SDK for Falco libs
         has_projects: true
         has_wiki: false
       libscap:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         has_projects: true
       libsinsp:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
-        description: System inspection library
+        description: "System inspection library "
         has_projects: true
       pdig:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         archived: true
         description: ptrace-based event producer for udig
         has_projects: true
         has_wiki: false
       plugin-sdk-cpp:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         has_projects: true
       plugin-sdk-go:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         default_branch: main
         has_projects: true
       plugins:
+        allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
+        description: Falco plugins registry
         has_projects: true
       template-repository:
-        archived: true
         allow_merge_commit: false
+        allow_rebase_merge: false
         allow_squash_merge: false
+        archived: true
         description: Acts as a template for new repositories
         has_projects: true
       test-infra:
         allow_merge_commit: false
+        allow_rebase_merge: false
+        allow_squash_merge: false
         description: Falco workflow & testing infrastructure
         has_projects: true
         has_wiki: false
@@ -215,7 +287,7 @@ orgs:
     teams:
       admins:
         description: admins of the org
-        members:
+        maintainers:
           - caniszczyk
           - ldegio
           - leogr
@@ -224,37 +296,22 @@ orgs:
         privacy: closed
         repos:
           advocacy: admin
-      core-maintainers:
-        description: Core maintainers of The Falco Project
-        members:
-          - andreagit97
-          - cpanato
-          - fededp
-          - gnosek
-          - issif
-          - jasondellaluce
-          - leogr
-          - lucaguerra
-          - maxgio92
-          - molter73
-          - mstemm
-          - zuc
-        privacy:
-        repos:
       charts-maintainers:
         description: maintainers of falcosecurity/charts
-        members:
+        maintainers:
           - leogr
-          - Issif
+        members:
           - cpanato
+          - Issif
         privacy: closed
         repos:
           charts: maintain
       client-go-maintainers:
         description: maintainers of falcosecurity/client-go
+        maintainers:
+          - leogr
         members:
           - leodido
-          - leogr
         privacy: closed
         repos:
           client-go: maintain
@@ -275,32 +332,52 @@ orgs:
           client-rs: maintain
       community-maintainers:
         description: maintainers of falcosecurity/community
-        members:
+        maintainers:
           - leogr
+        members:
           - Issif
-          - Andreagit97
-          - terylt
-          - maxgio92
           - araujof
+          - maxgio92
+          - terylt
+          - Andreagit97
         privacy: closed
         repos:
           community: maintain
       contrib-maintainers:
         description: maintainers of falcosecurity/contrib
-        members:
+        maintainers:
           - leogr
+        members:
           - maxgio92
           - jasondellaluce
         privacy: closed
         repos:
           contrib: maintain
+      core-maintainers:
+        description: Core maintainers of The Falco Project
+        maintainers:
+          - leogr
+          - mstemm
+        members:
+          - gnosek
+          - cpanato
+          - Issif
+          - FedeDP
+          - maxgio92
+          - zuc
+          - jasondellaluce
+          - Molter73
+          - LucaGuerra
+          - Andreagit97
+        privacy: closed
       deploy-kubernetes-maintainers:
         description: maintainers of falcosecurity/deploy-kubernetes
-        members:
+        maintainers:
           - leogr
+        members:
           - maxgio92
-          - jasondellaluce
           - zuc
+          - jasondellaluce
         privacy: closed
         repos:
           deploy-kubernetes: maintain
@@ -309,22 +386,24 @@ orgs:
         members:
           - leodido
           - dwindsor
-          - fededp
+          - FedeDP
         privacy: closed
         repos:
           driverkit: maintain
       event-generator-maintainers:
         description: maintainers of falcosecurity/event-generator
-        members:
+        maintainers:
           - leogr
-          - fededp
+        members:
+          - FedeDP
         privacy: closed
         repos:
           event-generator: maintain
       evolution-maintainers:
         description: maintainers of falcosecurity/evolution
-        members:
+        maintainers:
           - leogr
+        members:
           - maxgio92
           - jasondellaluce
         privacy: closed
@@ -332,55 +411,60 @@ orgs:
           evolution: maintain
       falco-aws-terraform-maintainers:
         description: maintainers of falcosecurity/falco-aws-terraform
-        members:
-          - mstemm
-          - leogr
-          - jasondellaluce
+        maintainers:
           - ldegio
+          - leogr
+          - mstemm
+        members:
           - zuc
+          - jasondellaluce
         privacy: closed
         repos:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
         description: maintainers of falcosecurity/falco-exporter
-        members:
+        maintainers:
           - leogr
+        members:
           - jasondellaluce
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
         description: maintainers of falcosecurity/falco
-        members:
-          - mstemm
+        maintainers:
           - leogr
+          - mstemm
+        members:
+          - FedeDP
           - jasondellaluce
-          - fededp
         privacy: closed
         repos:
           falco: maintain
       falco-website-maintainers:
         description: maintainers of falcosecurity/falco-website
-        members:
+        maintainers:
           - leogr
-          - jasondellaluce
+        members:
           - Issif
+          - jasondellaluce
         privacy: closed
         repos:
           falco-website: maintain
       falcoctl-maintainers:
         description: maintainers of falcosecurity/falcoctl
-        members:
+        maintainers:
           - leogr
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
         description: maintainers of falcosecurity/falcosidekick
-        members:
-          - Issif
+        maintainers:
           - leogr
+        members:
           - cpanato
+          - Issif
           - fjogeleit
         privacy: closed
         repos:
@@ -388,25 +472,28 @@ orgs:
       falcosidekick-ui-maintainers:
         description: maintainers of falcosecurity/falcosidekick-ui
         members:
-          - Issif
           - cpanato
+          - Issif
           - fjogeleit
         privacy: closed
         repos:
           falcosidekick-ui: maintain
       github-maintainers:
         description: maintainers of falcosecurity/.github
-        members:
+        maintainers:
           - leogr
+        members:
           - maxgio92
+        privacy: closed
         repos:
           .github: maintain
       kernel-crawler-maintainers:
         description: maintainers of falcosecurity/kernel-crawler
-        members:
-          - fededp
-          - maxgio92
+        maintainers:
           - leogr
+        members:
+          - FedeDP
+          - maxgio92
           - zuc
         privacy: closed
         repos:
@@ -414,39 +501,41 @@ orgs:
       kilt-maintainers:
         description: maintainers of falcosecurity/kilt
         members:
-          - admiral0
-          - leodido
           - gnosek
+          - leodido
+          - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
         description: maintainers of falcosecurity/libs
-        members:
+        maintainers:
           - leogr
-          - gnosek
           - mstemm
-          - fededp
-          - andreagit97
-          - molter73
+        members:
+          - gnosek
+          - FedeDP
+          - Molter73
           - LucaGuerra
+          - Andreagit97
         privacy: closed
         repos:
           libs: maintain
       libs-sdk-go-maintainers:
         description: maintainers of falcosecurity/libs-sdk-go
+        maintainers:
+          - leogr
         members:
           - araujof
-          - terylt
-          - leogr
           - jasondellaluce
-          - andreagit97
+          - terylt
+          - Andreagit97
         privacy: closed
         repos:
           libs-sdk-go: maintain
       machine_users:
         description: bots
-        members:
+        maintainers:
           - poiana
         privacy: closed
         repos:
@@ -479,8 +568,9 @@ orgs:
           test-infra: admin
       pdig-maintainers:
         description: maintainers of falcosecurity/pdig
-        members:
+        maintainers:
           - ldegio
+        members:
           - gnosek
           - leodido
         privacy: closed
@@ -488,39 +578,43 @@ orgs:
           pdig: maintain
       plugin-sdk-cpp-maintainers:
         description: maintainers of falcosecurity/plugin-sdk-cpp
-        members:
+        maintainers:
           - ldegio
-          - leodido
-          - mstemm
           - leogr
-          - fededp
+          - mstemm
+        members:
+          - leodido
+          - FedeDP
         privacy: closed
         repos:
           plugin-sdk-cpp: maintain
       plugin-sdk-go-maintainers:
         description: maintainers of falcosecurity/plugin-sdk-go
-        members:
+        maintainers:
           - leogr
+        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
         description: maintainers of falcosecurity/plugins
-        members:
-          - mstemm
+        maintainers:
           - leogr
+          - mstemm
+        members:
           - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       test-infra-maintainers:
         description: maintainers of falcosecurity/test-infra
+        maintainers:
+          - leogr
         members:
           - maxgio92
-          - jonahjon
-          - leogr
           - zuc
+          - jonahjon
         privacy: closed
         repos:
           test-infra: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -28,6 +28,7 @@ orgs:
       - FedeDP
       - fjogeleit
       - gnosek
+      - hbrueckner
       - Issif
       - jonahjon
       - Kaizhe

--- a/org.yaml
+++ b/org.yaml
@@ -458,6 +458,11 @@ orgs:
         description: maintainers of falcosecurity/falcoctl
         maintainers:
           - leogr
+        members:
+          - zuc
+          - maxgio92
+          - fededp
+          - cpanato
         privacy: closed
         repos:
           falcoctl: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -422,6 +422,7 @@ orgs:
         maintainers:
           - leodido
           - fntlnz
+          - gnosek
         members:
           - admiral0
         privacy: closed

--- a/org.yaml
+++ b/org.yaml
@@ -46,7 +46,7 @@ orgs:
     repos:
       .github:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: Default community health files
@@ -54,27 +54,27 @@ orgs:
         has_wiki: false
       advocacy:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: Advocacy machinery
         has_projects: true
       charts:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Community managed Helm charts for running Falco with Kubernetes
         has_projects: true
         has_wiki: false
       client-go:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Go client and SDK for Falco
         has_projects: true
       client-py:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: Python client and SDK for Falco
@@ -82,14 +82,14 @@ orgs:
         has_wiki: false
       client-rs:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: The rust language implementation of the Falco client
         has_projects: true
       community:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: The Falco Project Community
@@ -97,7 +97,7 @@ orgs:
         has_wiki: false
       contrib:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: Community sandbox to test-drive ideas/projects/code
@@ -105,7 +105,7 @@ orgs:
         has_wiki: false
       deploy-kubernetes:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: Kubernetes deployment resources for Falco
@@ -113,20 +113,20 @@ orgs:
         has_wiki: false
       driverkit:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: "Kit for building Falco drivers: kernel modules or eBPF probes"
         has_projects: true
       ebpf-probe:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: eBPF probe for syscall events
         has_projects: true
       event-generator:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description:
           Generate a variety of suspect actions that are detected by Falco
@@ -134,7 +134,7 @@ orgs:
         has_projects: true
       evolution:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: Evolution process of The Falco Project
@@ -142,7 +142,7 @@ orgs:
         has_wiki: false
       falco:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Cloud Native Runtime Security
         has_projects: true
@@ -150,48 +150,48 @@ orgs:
         homepage: https://falco.org
       falco-aws-terraform:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Terraform Module for Falco AWS Resources
         default_branch: main
         has_projects: true
       falco-exporter:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Prometheus Metrics Exporter for Falco output events
         has_projects: true
       falco-website:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Source code of the official Falco website
         has_projects: true
         homepage: https://falco.org
       falcoctl:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Administrative tooling for Falco
         has_projects: true
         has_wiki: false
       falcosidekick:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Connect Falco to your ecosystem
         has_projects: true
         has_wiki: false
       falcosidekick-ui:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: A simple WebUI with latest events from Falco
         has_projects: true
         has_wiki: false
       kernel-crawler:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: A tool to crawl Linux kernel versions
@@ -199,20 +199,20 @@ orgs:
         has_wiki: false
       kernel-module:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         has_projects: true
       kilt:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Kilt is a project that defines how to inject foreign apps into containers
         has_projects: true
         has_wiki: false
       libs:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description:
           libsinsp, libscap, the kernel module driver, and the eBPF driver
@@ -221,7 +221,7 @@ orgs:
         has_wiki: false
       libs-sdk-go:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         default_branch: main
         description: Go SDK for Falco libs
@@ -229,20 +229,20 @@ orgs:
         has_wiki: false
       libscap:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         has_projects: true
       libsinsp:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: "System inspection library "
         has_projects: true
       pdig:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: ptrace-based event producer for udig
@@ -250,33 +250,33 @@ orgs:
         has_wiki: false
       plugin-sdk-cpp:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Falco plugins SDK for C++
         has_projects: true
       plugin-sdk-go:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Falco plugins SDK for Go
         default_branch: main
         has_projects: true
       plugins:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Falco plugins registry
         has_projects: true
       template-repository:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         archived: true
         description: Acts as a template for new repositories
         has_projects: true
       test-infra:
         allow_merge_commit: false
-        allow_rebase_merge: false
+        allow_rebase_merge: true
         allow_squash_merge: false
         description: Falco workflow & testing infrastructure
         has_projects: true

--- a/org.yaml
+++ b/org.yaml
@@ -199,6 +199,7 @@ orgs:
       plugins:
         has_projects: true
       template-repository:
+        archived: true
         allow_merge_commit: false
         allow_squash_merge: false
         description: Acts as a template for new repositories

--- a/org.yaml
+++ b/org.yaml
@@ -43,6 +43,7 @@ orgs:
       - maxgio92
       - mfdii
       - mmat11
+      - Molter73
       - mumoshu
       - nestorsalceda
       - nibalizer
@@ -436,6 +437,7 @@ orgs:
           - Andreagit97
           - gnosek
           - FedeDP
+          - Molter73
         privacy: closed
         repos:
           libs: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -156,6 +156,7 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: false
         allow_squash_merge: false
+        description: Terraform Module for Falco AWS Resources
         default_branch: main
         has_projects: true
       falco-exporter:
@@ -168,7 +169,7 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: false
         allow_squash_merge: false
-        description: Hugo content to generate website content. Hosted by the CNCF
+        description: Source code of the official Falco website
         has_projects: true
         homepage: https://falco.org
       falcoctl:
@@ -255,11 +256,13 @@ orgs:
         allow_merge_commit: false
         allow_rebase_merge: false
         allow_squash_merge: false
+        description: Falco plugins SDK for C++
         has_projects: true
       plugin-sdk-go:
         allow_merge_commit: false
         allow_rebase_merge: false
         allow_squash_merge: false
+        description: Falco plugins SDK for Go
         default_branch: main
         has_projects: true
       plugins:

--- a/org.yaml
+++ b/org.yaml
@@ -212,25 +212,24 @@ orgs:
         repos:
           advocacy: admin
       charts-maintainers:
-        description: maintainers of the Falco Helm charts
+        description: maintainers of falcosecurity/charts
         members:
           - leogr
-          - cpanato
           - Issif
+          - cpanato
         privacy: closed
         repos:
           charts: maintain
       client-go-maintainers:
-        description: maintainers of client-go
+        description: maintainers of falcosecurity/client-go
         members:
           - leodido
           - leogr
-          - markyjackson-taulia
         privacy: closed
         repos:
           client-go: maintain
       client-py-maintainers:
-        description: maintainers of client-py
+        description: maintainers of falcosecurity/client-py
         members:
           - leodido
           - mmat11
@@ -238,30 +237,36 @@ orgs:
         repos:
           client-py: maintain
       client-rs-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/client-rs
         members:
           - leodido
         privacy: closed
         repos:
           client-rs: maintain
       community-maintainers:
-        description: maintainers of the community repository
+        description: maintainers of falcosecurity/community
         members:
           - leogr
+          - Issif
+          - Andreagit97
+          - terylt
+          - maxgio92
+          - araujof
         privacy: closed
         repos:
           community: maintain
       deploy-kubernetes-maintainers:
-        description: maintainers of deploy-kubernetes
+        description: maintainers of falcosecurity/deploy-kubernetes
         members:
           - leogr
           - maxgio92
           - jasondellaluce
+          - zuc
         privacy: closed
         repos:
           deploy-kubernetes: maintain
       driverkit-maintainers:
-        description: maintainers of driverkit
+        description: maintainers of falcosecurity/driverkit
         members:
           - leodido
           - dwindsor
@@ -270,7 +275,7 @@ orgs:
         repos:
           driverkit: maintain
       event-generator-maintainers:
-        description: maintainers of the event-generator
+        description: maintainers of falcosecurity/event-generator
         members:
           - leogr
           - fededp
@@ -278,16 +283,15 @@ orgs:
         repos:
           event-generator: maintain
       evolution-maintainers:
-        description: maintainers of the evolution repository
+        description: maintainers of falcosecurity/evolution
         members:
           - leogr
-          - nestorsalceda
           - maxgio92
         privacy: closed
         repos:
           evolution: maintain
       falco-aws-terraform-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/falco-aws-terraform
         members:
           - mstemm
           - leogr
@@ -298,46 +302,52 @@ orgs:
         repos:
           falco-aws-terraform: maintain
       falco-exporter-maintainers:
-        description: maintainers of falco-exporter
+        description: maintainers of falcosecurity/falco-exporter
         members:
           - leogr
+          - jasondellaluce
         privacy: closed
         repos:
           falco-exporter: maintain
       falco-maintainers:
-        description: maintainers of the main Falco repository
+        description: maintainers of falcosecurity/falco
         members:
-          - leogr
           - mstemm
+          - leogr
           - jasondellaluce
           - fededp
-          - Kaizhe
         privacy: closed
         repos:
           falco: maintain
-      falcoctl-maintainers:
-        description: falcoctl maintainers
+      falco-website-maintainers:
+        description: maintainers of falcosecurity/falco-website
         members:
           - leogr
-          - mstemm
-          - markyjackson-taulia
+          - jasondellaluce
+          - Issif
+        privacy: closed
+        repos:
+          falco-website: maintain
+      falcoctl-maintainers:
+        description: maintainers of falcosecurity/falcoctl
+        members:
+          - leogr
         privacy: closed
         repos:
           falcoctl: maintain
       falcosidekick-maintainers:
-        description: maintainers of falcosidekick
+        description: maintainers of falcosecurity/falcosidekick
         members:
-          - leogr
           - Issif
+          - leogr
           - cpanato
           - fjogeleit
         privacy: closed
         repos:
           falcosidekick: maintain
       falcosidekick-ui-maintainers:
-        description: maintainers of falcosidekick-ui
+        description: maintainers of falcosecurity/falcosidekick-ui
         members:
-          - leogr
           - Issif
           - cpanato
           - fjogeleit
@@ -345,14 +355,14 @@ orgs:
         repos:
           falcosidekick-ui: maintain
       github-maintainers:
-        description: maintainers of the .github repository
+        description: maintainers of falcosecurity/.github
         members:
           - leogr
           - maxgio92
         repos:
           .github: maintain
       kernel-crawler-maintainers:
-        description: kernel-crawler maintainers
+        description: maintainers of falcosecurity/kernel-crawler
         members:
           - fededp
           - maxgio92
@@ -362,34 +372,34 @@ orgs:
         repos:
           kernel-crawler: maintain
       kilt-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/kilt
         members:
+          - admiral0
           - leodido
           - gnosek
-          - admiral0
         privacy: closed
         repos:
           kilt: maintain
       libs-maintainers:
-        description: libs maintainers
+        description: maintainers of falcosecurity/libs
         members:
-          - ldegio
           - leogr
-          - Andreagit97
           - gnosek
+          - mstemm
           - fededp
-          - Molter73
+          - andreagit97
+          - molter73
         privacy: closed
         repos:
           libs: maintain
       libs-sdk-go-maintainers:
-        description: libs-sdk-go maintainers
+        description: maintainers of falcosecurity/libs-sdk-go
         members:
           - araujof
           - terylt
           - leogr
           - jasondellaluce
-          - Andreagit97
+          - andreagit97
         privacy: closed
         repos:
           libs-sdk-go: maintain
@@ -405,6 +415,7 @@ orgs:
           client-py: admin
           client-rs: admin
           community: admin
+          deploy-kubernetes: admin
           driverkit: admin
           event-generator: admin
           evolution: admin
@@ -415,70 +426,59 @@ orgs:
           falcoctl: admin
           falcosidekick: admin
           falcosidekick-ui: admin
-          katacoda-scenarios: admin
+          kernel-crawler: admin
           kilt: admin
           libs: admin
+          libs-sdk-go: admin
           pdig: admin
+          plugin-sdk-cpp: admin
           plugin-sdk-go: admin
           plugins: admin
-          template-repository: admin
           test-infra: admin
       pdig-maintainers:
-        description: maintainers of pdig
+        description: maintainers of falcosecurity/pdig
         members:
-          - leodido
           - ldegio
           - gnosek
+          - leodido
         privacy: closed
         repos:
           pdig: maintain
       plugin-sdk-cpp-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugin-sdk-cpp
         members:
-          - leodido
           - ldegio
-          - leogr
+          - leodido
           - mstemm
+          - leogr
           - fededp
         privacy: closed
         repos:
-          plugin-sdk-cpp: read
+          plugin-sdk-cpp: maintain
       plugin-sdk-go-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugin-sdk-go
         members:
-          - ldegio
           - leogr
-          - mstemm
           - jasondellaluce
         privacy: closed
         repos:
           plugin-sdk-go: maintain
       plugins-maintainers:
-        description: ""
+        description: maintainers of falcosecurity/plugins
         members:
-          - ldegio
-          - leogr
           - mstemm
+          - leogr
           - jasondellaluce
         privacy: closed
         repos:
           plugins: maintain
       test-infra-maintainers:
-        description: Maintainers of falcosecurity/test-infra
+        description: maintainers of falcosecurity/test-infra
         members:
-          - leogr
           - maxgio92
-          - zuc
           - jonahjon
+          - leogr
+          - zuc
         privacy: closed
         repos:
           test-infra: maintain
-      website-maintainers:
-        description: maintainers of falco-website and docs
-        members:
-          - leogr
-          - jasondellaluce
-          - Issif
-        privacy: closed
-        repos:
-          falco-website: maintain

--- a/org.yaml
+++ b/org.yaml
@@ -220,6 +220,23 @@ orgs:
         privacy: closed
         repos:
           advocacy: admin
+      core-maitainers:
+        description: Core maintainers of The Falco Project
+        members:
+          - andreagit97
+          - cpanato
+          - fededp
+          - gnosek
+          - issif
+          - jasondellaluce
+          - leogr
+          - lucaguerra
+          - maxgio92
+          - molter73
+          - mstemm
+          - zuc
+        privacy:
+        repos:
       charts-maintainers:
         description: maintainers of falcosecurity/charts
         members:

--- a/org.yaml
+++ b/org.yaml
@@ -271,6 +271,13 @@ orgs:
         allow_squash_merge: false
         description: Falco plugins registry
         has_projects: true
+      rules:
+        allow_merge_commit: false
+        allow_rebase_merge: true
+        allow_squash_merge: false
+        description: Falco rule repository
+        has_projects: false
+        has_wiki: false
       syscalls-bumper:
         allow_merge_commit: false
         allow_rebase_merge: true
@@ -628,6 +635,14 @@ orgs:
         privacy: closed
         repos:
           plugins: maintain
+      rules-maintainers:
+        description: maintainers of falcosecurity/rules
+        maintainers:
+          - leogr
+          - LucaGuerra
+        privacy: closed
+        repos:
+          rules: maintain
       syscalls-bumper-maintainers:
         description: maintainers of falcosecurity/syscalls-bumper
         maintainers:

--- a/org.yaml
+++ b/org.yaml
@@ -664,6 +664,7 @@ orgs:
         maintainers:
           - maxgio92
           - leogr
+          - FedeDP
         members: []
         privacy: closed
         repos:

--- a/org.yaml
+++ b/org.yaml
@@ -10,7 +10,6 @@ orgs:
 
     admins:
       - caniszczyk
-      - kris-nova
       - ldegio
       - leogr
       - mstemm
@@ -36,6 +35,7 @@ orgs:
       - jonahjon
       - Kaizhe
       - KeisukeYamashita
+      - kris-nova
       - leodido
       - lucperkins
       - markyjackson-taulia
@@ -221,7 +221,6 @@ orgs:
           - leogr
           - thelinuxfoundation
           - mstemm
-          - kris-nova
         privacy: closed
         repos:
           advocacy: admin
@@ -229,7 +228,6 @@ orgs:
         description: maintainers of the Falco Helm charts
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nibalizer
           - cpanato
@@ -242,7 +240,6 @@ orgs:
         maintainers:
           - leodido
           - leogr
-          - kris-nova
         members:
           - mfdii
           - markyjackson-taulia
@@ -269,7 +266,6 @@ orgs:
         description: maintainers of the community repository
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nibalizer
           - mfdii
@@ -298,7 +294,6 @@ orgs:
         description: maintainers of the event-generator
         maintainers:
           - leogr
-          - kris-nova
           - fededp
         privacy: closed
         repos:
@@ -307,7 +302,6 @@ orgs:
         description: maintainers of the evolution repository
         maintainers:
           - leogr
-          - kris-nova
         members:
           - nestorsalceda
           - maxgio92
@@ -337,7 +331,6 @@ orgs:
         maintainers:
           - leogr
           - mstemm
-          - kris-nova
           - jasondellaluce
           - fededp
         members:
@@ -350,7 +343,6 @@ orgs:
         maintainers:
           - leogr
           - mstemm
-          - kris-nova
         members:
           - markyjackson-taulia
         privacy: closed
@@ -469,7 +461,6 @@ orgs:
         description: falconers (can dismiss reviews and apply milestones)
         maintainers:
           - leogr
-          - kris-nova
         members:
           - jasondellaluce
         privacy: secret
@@ -503,7 +494,6 @@ orgs:
           - ldegio
           - leogr
           - mstemm
-          - kris-nova
         members:
           - jasondellaluce
         privacy: closed
@@ -515,7 +505,6 @@ orgs:
           - ldegio
           - leogr
           - mstemm
-          - kris-nova
         members:
           - jasondellaluce
         privacy: closed
@@ -536,7 +525,6 @@ orgs:
         description: maintainers of falco-website and docs
         maintainers:
           - leogr
-          - kris-nova
         members:
           - lucperkins
           - mfdii

--- a/org.yaml
+++ b/org.yaml
@@ -33,7 +33,7 @@ orgs:
       - Issif
       - jonahjon
       - Kaizhe
-      - kris-nova
+      - krisnova
       - leodido
       - loresuso
       - LucaGuerra

--- a/org.yaml
+++ b/org.yaml
@@ -26,6 +26,7 @@ orgs:
       - cpanato
       - darryk10
       - dwindsor
+      - EXONER4TED
       - FedeDP
       - fjogeleit
       - gnosek


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area utils

**What this PR does / why we need it**:

As the evolution repository is now the central point for the evolution of the project, and as the falcosecurity organization is formed by the community, and as the point of contact of the contributions are in git (Github), is correct that the source of truth as a declarative configuration of the Github organization is put here.

Moreover, this PR adds the Prow job needed for the automation that reconciles the desired source of truth with the actual one.

**Which issue(s) this PR fixes**:

Fixes #176 

Supersedes #204

/cc @leogr 