### PR TITLE
update(repositories.yaml): demote to sandbox repos don't matching inc…

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -77,7 +77,7 @@
   description: Foundational libraries that constitute the core of Falco's functionality, offering essential features including kernel drivers and eBPF probes.
 - name: libs-sdk-go
   scope: Ecosystem
-  status: Incubating
+  status: Sandbox
   description: Go SDK for Falco libs.
 - name: pigeon
   scope: Infra
@@ -85,7 +85,7 @@
   description: Secrets and config manager for Falco's infrastructure.
 - name: plugin-sdk-cpp
   scope: Ecosystem
-  status: Incubating
+  status: Sandbox
   description: Falco plugins SDK for C++.
 - name: plugin-sdk-go
   scope: Core


### PR DESCRIPTION
**What type of PR is this?**


/kind sandbox

> /kind deprecated


<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area governance

> /area proposals

> /area utils


<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Since the following repos do not match the criteria for the [incubating status](https://github.com/falcosecurity/evolution/blob/main/REPOSITORIES.md#incubating) anymore
- https://github.com/falcosecurity/plugin-sdk-cpp has no releases and is not regularly updated
- https://github.com/falcosecurity/libs-sdk-go has no releases and is still experimental

This PR demotes them to *sandbox*.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #

**Special notes for your reviewer**:

I've already opened the PRs to update the badges in those repositories:

- https://github.com/falcosecurity/plugin-sdk-cpp/pull/16 
- https://github.com/falcosecurity/libs-sdk-go/pull/1